### PR TITLE
Ghrustworkflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,4 @@ jobs:
         ["debian/debian/bookworm", "ubuntu/ubuntu/jammy"]
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   rust:
-    uses: lpenz/ghworkflow-rust/.github/workflows/rust.yml@v0.23.3
+    uses: esomore/ghworkflow-rust/.github/workflows/rust.yml@esomore-fix-codecov-action
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,14 @@
-on: [push]
-
+---
 name: CI
-
+on: [push, pull_request]
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy
-
-      # `cargo check` command here will use installed `nightly`
-      # as it is set as an "override" for current directory
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+  rust:
+    uses: lpenz/ghworkflow-rust/.github/workflows/rust.yml@v0.23.3
+    with:
+      coveralls: true
+      codecov: true
+      deb: true
+      publish_packagecloud_repository: |
+        ["debian/debian/bookworm", "ubuntu/ubuntu/jammy"]
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
     with:
       coveralls: true
       codecov: true
-      deb: true
-      publish_packagecloud_repository: |
-        ["debian/debian/bookworm", "ubuntu/ubuntu/jammy"]
+      publish_cratesio: true
+      publish_github_release: true
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 jobs:
   rust:
     uses: lpenz/ghworkflow-rust/.github/workflows/rust.yml@v0.23.3
+    permissions:
+      contents: read
+      issues: write
     with:
       coveralls: true
       codecov: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,3 @@ jobs:
         ["debian/debian/bookworm", "ubuntu/ubuntu/jammy"]
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
       publish_cratesio: true
       publish_github_release: true
     secrets:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This pull request includes significant changes to the continuous integration (CI) workflow in the `.github/workflows/ci.yml` file. The most important changes involve updating the CI configuration to use a shared workflow and adding support for additional actions and permissions.

Changes to CI configuration:

* Updated the `on` trigger to include both `push` and `pull_request` events, ensuring that the CI pipeline runs on both types of events.
* Replaced the custom job configuration with a shared workflow from `lpenz/ghworkflow-rust`, simplifying the CI setup and maintenance.
* Added permissions for reading contents and writing issues, enhancing the CI workflow's capabilities.
* Enabled additional actions such as Coveralls and Codecov for code coverage reporting, and configured package publishing to specific repositories.
* Included a secret for the Cargo registry token to securely publish Rust packages.