### PR TITLE
Fix Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,4 @@ jobs:
         ["debian/debian/bookworm", "ubuntu/ubuntu/jammy"]
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   rust:
-    uses: lpenz/ghworkflow-rust/.github/workflows/rust.yml@v0.23.3
+    uses: esomore/ghworkflow-rust/.github/workflows/rust.yml@esomore-fix-codecov-action
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,4 @@ jobs:
       publish_github_release: true
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,14 @@
-on: [push]
-
+---
 name: CI
-
+on: [push, pull_request]
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install latest nightly
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          components: rustfmt, clippy
-
-      # `cargo check` command here will use installed `nightly`
-      # as it is set as an "override" for current directory
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+  rust:
+    uses: lpenz/ghworkflow-rust/.github/workflows/rust.yml@v0.23.3
+    with:
+      coveralls: true
+      codecov: true
+      deb: true
+      publish_packagecloud_repository: |
+        ["debian/debian/bookworm", "ubuntu/ubuntu/jammy"]
+    secrets:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,7 @@ jobs:
     with:
       coveralls: true
       codecov: true
-      deb: true
-      publish_packagecloud_repository: |
-        ["debian/debian/bookworm", "ubuntu/ubuntu/jammy"]
+      publish_cratesio: true
+      publish_github_release: true
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on: [push, pull_request]
 jobs:
   rust:
     uses: lpenz/ghworkflow-rust/.github/workflows/rust.yml@v0.23.3
+    permissions:
+      contents: read
+      issues: write
     with:
       coveralls: true
       codecov: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,3 @@ jobs:
         ["debian/debian/bookworm", "ubuntu/ubuntu/jammy"]
     secrets:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push, pull_request]
 jobs:
   rust:
-    uses: esomore/ghworkflow-rust/.github/workflows/rust.yml@esomore-fix-codecov-action
+    uses: esomore/ghworkflow-rust/.github/workflows/rust.yml@main
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,4 @@ jobs:
       publish_cratesio: true
       publish_github_release: true
     secrets:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
This pull request includes significant updates to the CI workflow configuration. The most important changes include renaming the workflow, expanding the events that trigger the workflow, and delegating the job execution to an external reusable workflow.

Updates to CI workflow configuration:

* Renamed the workflow from an unnamed state to `CI`.
* Expanded the events that trigger the workflow to include both `push` and `pull_request`.
* Delegated the job execution to an external reusable workflow `esomore/ghworkflow-rust/.github/workflows/rust.yml@main`.
* Added permissions configuration for `contents: read` and `issues: write`.
* Configured secrets for publishing to crates.io and GitHub releases using `CARGO_REGISTRY_TOKEN`.