### PR TITLE
Bump merka-vault2 version to 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "merka-vault2"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "merka-vault2"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Vault provisioning and management crate integrating with merka-core"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This pull request includes a small change to the `Cargo.toml` file. The change updates the version of the `merka-vault2` package from `0.1.4` to `0.1.5`.